### PR TITLE
New JWT authentication API

### DIFF
--- a/routes/api/login.js
+++ b/routes/api/login.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 const express = require("express");
 const jwt = require("jsonwebtoken");
-const { conn } = require("./dbconnect.js");
+const { conn } = require("../../utils/dbconnect.js");
 const bcrypt = require("bcrypt");
 const app = express();
 const bodyParser = require("body-parser");

--- a/routes/api/verifyjwtmiddleware.js
+++ b/routes/api/verifyjwtmiddleware.js
@@ -1,12 +1,7 @@
-const express = require("express");
+require('dotenv').config();
 const jwt = require("jsonwebtoken");
-const app = express();
-const router = express.Router();
 
-//Token verification middleware
-//verifyToken();
-
-router.post("/", (req, res) => {
+function verifyToken(req, res, next){
   //Get auth header value
   const bearerHeader = req.headers['authorization'];
   //check if bearer is undefined
@@ -26,14 +21,13 @@ router.post("/", (req, res) => {
       };
       console.log("This token is genuine: " + JSON.stringify(authData));
       req.user_id = authData.user_id;
-      return res.sendStatus(200);
+      next();
     });
   } else {
     //There is no bearer token present
     //send an error that will trigger redirect to login page
     return res.status(401).json({ errorMsg: "The JWT was invalid."});
   }
-});
+}
 
-
-module.exports = router;
+module.exports = { verifyToken };


### PR DESCRIPTION
• New JWT authentication API created to verify that a user on the iOS app has a genuine token and can be on user only pages
• JWT middleware renames to 'verifyjwtmiddleware' to differentiate from standalone authentication API